### PR TITLE
hotfix/credential_PhD_removed_on_occupancy_updates

### DIFF
--- a/api/workforce/models/occupancy.go
+++ b/api/workforce/models/occupancy.go
@@ -233,7 +233,7 @@ func UpdateOccupancy(db *pgxpool.Pool, o Occupancy) (*Occupancy, error) {
 	if _, err = tx.Exec(ctx,
 		`DELETE FROM occupant_credentials
 	     WHERE occupancy_id = $1 AND credential_id NOT IN (
-		 	SELECT id FROM credential WHERE abbrev = ANY($2)
+		 	SELECT id FROM credential WHERE UPPER(abbrev) = ANY($2)
 		 )`, o.ID, credAbbrevs,
 	); err != nil {
 		return nil, err
@@ -256,7 +256,7 @@ func UpdateOccupancy(db *pgxpool.Pool, o Occupancy) (*Occupancy, error) {
 				FROM occupancy
 				WHERE id = $1
 			) o
-			WHERE oc.credential_id IS NULL AND c.abbrev = ANY($2)
+			WHERE oc.credential_id IS NULL AND UPPER(c.abbrev) = ANY($2)
 		)
 		INSERT INTO occupant_credentials
 		SELECT * FROM creds`,


### PR DESCRIPTION
Any updates to `occupancy` were removing the credential "PhD" from the occupancy.  This is because the uppercase version of the credential, i.e. `PHD` was not matching the actual abbreviation stored in the database (PhD).  SQL has been updated to be case insensitive. This was only affecting the credential PhD, as it is the only credential with a mixed-case abbreviation.